### PR TITLE
Fix cookie auth failure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,12 +192,15 @@ async fn verify_query_params(value: GetAuthParams) -> Result<DtzProfile, String>
 
 fn verify_token_from_cookie(cookie: HeaderValue) -> Result<DtzProfile, String> {
     let cookie_str = cookie.to_str().unwrap();
-    let mut final_cookie = None;
+    let mut final_cookie: Option<String> = None;
     for cookie in Cookie::split_parse(cookie_str) {
-        let cookie = cookie.unwrap();
-        if cookie.name() == "dtz-auth" {
-            let c = cookie.value().to_string();
-            final_cookie = Some(c);
+        match cookie {
+            Ok(cookie) => {
+                if cookie.name() == "dtz-auth" {
+                    final_cookie = Some(cookie.value().to_string());
+                }
+            }
+            Err(_) => continue,
         }
     }
     if let Some(token) = final_cookie {

--- a/src/test.rs
+++ b/src/test.rs
@@ -190,6 +190,15 @@ fn multiple_cookies() {
 }
 
 #[test]
+fn invalid_cookie_in_header() {
+    let cookie_str = "dtz-auth=abcd; broken";
+    let cookie = HeaderValue::from_static(cookie_str);
+    let result = crate::verify_token_from_cookie(cookie);
+    println!("{result:?}");
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_api_key_url() {
     let url = "https://billing.dtz.rocks/api/2022-12-28/charge/stripe?apiKey=apikey-00000000-0000-0000-0000-000000000000";
     let uri = Uri::from_static(url);


### PR DESCRIPTION
## Summary
- handle invalid cookies when searching for `dtz-auth`
- add regression test for invalid cookie parsing

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_b_6851dd56586c8329bc3c540131101fe4